### PR TITLE
Add Docker Compose multi-service orchestration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,38 @@
+services:
+  backend:
+    build: ./backend
+    ports:
+      - "8000:8000"
+    env_file:
+      - .env
+    volumes:
+      - ./backend/app/engines/stock_sniper/data:/app/app/engines/stock_sniper/data
+      - ./backend/app/engines/crypto_sniper/data:/app/app/engines/crypto_sniper/data
+      - ./backend/app/engines/news_monitor/data:/app/app/engines/news_monitor/data
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/api/v1/health')"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+    restart: unless-stopped
+
+  telegram-bot:
+    build: ./telegram
+    env_file:
+      - .env
+    depends_on:
+      backend:
+        condition: service_healthy
+    restart: unless-stopped
+
+  frontend:
+    build: ./frontend
+    ports:
+      - "3000:3000"
+    depends_on:
+      backend:
+        condition: service_healthy
+    environment:
+      - NEXT_PUBLIC_API_URL=http://localhost:8000
+    restart: unless-stopped


### PR DESCRIPTION
## Summary
- Configure `docker-compose.yml` with three services: backend, telegram-bot, frontend
- Add volume mounts for engine data persistence (stock, crypto, news alerts)
- Set up health-check based service dependencies (telegram-bot waits for backend)
- Configure frontend with `NEXT_PUBLIC_API_URL` environment variable
- Add Python-based healthcheck (avoids curl dependency in slim images)

Closes #3
Closes #4