### PR TITLE
Fix Docker, config, and environment issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,8 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
-lib64/
+/lib/
+/lib64/
 parts/
 sdist/
 var/


### PR DESCRIPTION
## Summary
- Fix `.gitignore` `lib/` pattern to `/lib/` so it doesn't match `frontend/src/lib/`
- Backend Dockerfile build order: source copied before `pip install` to prevent build failure
- Pydantic Settings: empty string → `None` conversion for optional integer env vars
- Docker Compose: frontend `NEXT_PUBLIC_API_URL` uses `localhost` (browser-accessible, not Docker-internal hostname)
- Docker Compose: healthcheck uses `python -c "import urllib.request; ..."` instead of `curl` (not available in `python:3.11-slim`)
- `.env.example` documents all required engine variables (`TELEGRAM_BOT_TOKEN`, `FINNHUB_API_KEY`, topic IDs, etc.)

Closes #49
Closes #50
Closes #51
Closes #52
Closes #53