### PR TITLE
Backend: Gemini AI service via Vertex AI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,23 @@ CRYPTO_NEWS_TOPIC_ID=112
 NEWS_FETCH_INTERVAL=300
 
 # =============================================================================
+# VERTEX AI CONFIGURATION
+# =============================================================================
+
+# Google Cloud project ID (find in GCP Console)
+VERTEX_PROJECT=your_gcp_project_id
+
+# Region where Vertex AI is enabled (us-central1 recommended for Gemini)
+VERTEX_LOCATION=us-central1
+
+# Gemini model to use via Vertex AI
+VERTEX_MODEL=gemini-2.5-flash
+
+# Path to your service account JSON key file
+# Create via: GCP Console → IAM → Service Accounts → Keys
+GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account-key.json
+
+# =============================================================================
 # GENERAL
 # =============================================================================
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -45,6 +45,11 @@ class Settings(BaseSettings):
     log_level: str = Field("INFO", alias="LOG_LEVEL")
     database_url: str = Field("sqlite:///bot.db", alias="DATABASE_URL")
 
+    # Vertex AI
+    vertex_project: str = Field("", alias="VERTEX_PROJECT")
+    vertex_location: str = Field("us-central1", alias="VERTEX_LOCATION")
+    vertex_model: str = Field("gemini-2.5-flash", alias="VERTEX_MODEL")
+
     # Stock algorithm thresholds
     algo_pe_threshold: float = Field(15.0, alias="ALGO_PE_THRESHOLD")
     algo_peg_threshold: float = Field(1.0, alias="ALGO_PEG_THRESHOLD")

--- a/backend/app/services/ai_service.py
+++ b/backend/app/services/ai_service.py
@@ -1,0 +1,214 @@
+"""
+AI service using Gemini via Vertex AI.
+
+Provides two main interfaces:
+- generate(): one-shot text generation (news analysis, summaries, etc.)
+- run_agent(): multi-turn agentic loop with function calling tools
+
+Authentication is handled via the GOOGLE_APPLICATION_CREDENTIALS env var,
+which should point to a service account JSON key file.
+"""
+
+import logging
+import json
+from dataclasses import dataclass, field
+from typing import Any, Callable, Optional
+
+import vertexai
+from vertexai.generative_models import (
+    GenerativeModel,
+    GenerationConfig,
+    Tool,
+    FunctionDeclaration,
+    Part,
+)
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+# Shared prompt templates used across features
+PROMPT_TEMPLATES = {
+    "market_analysis_stocks": (
+        "You are a concise financial analyst. Based on the following recent stock market news headlines, "
+        "write a single short paragraph (3-5 sentences) summarising the current state of the stock market. "
+        "Focus on themes, sectors, and sentiment. Do not make specific price predictions.\n\nHeadlines:\n{headlines}"
+    ),
+    "market_analysis_crypto": (
+        "You are a concise crypto analyst. Based on the following recent crypto news headlines, "
+        "write a single short paragraph (3-5 sentences) summarising the current state of the crypto market. "
+        "Focus on dominant narratives, sentiment, and major assets mentioned. Do not make specific price predictions.\n\nHeadlines:\n{headlines}"
+    ),
+}
+
+
+@dataclass
+class AgentTool:
+    """Wraps a callable tool that the agent can invoke during a multi-turn session."""
+
+    name: str
+    description: str
+    parameters: dict  # JSON Schema for the function parameters
+    handler: Callable[..., Any]
+
+    def to_function_declaration(self) -> FunctionDeclaration:
+        return FunctionDeclaration(
+            name=self.name,
+            description=self.description,
+            parameters=self.parameters,
+        )
+
+
+class AIService:
+    """
+    Central LLM integration point for the application.
+
+    Initialised once on startup; all features should use the singleton
+    returned by get_ai_service() rather than constructing their own instance.
+    """
+
+    def __init__(self):
+        self._initialised = False
+        self._model: Optional[GenerativeModel] = None
+
+    def _ensure_init(self):
+        if self._initialised:
+            return
+        if not settings.vertex_project:
+            raise RuntimeError(
+                "VERTEX_PROJECT is not set. Add it to your .env file."
+            )
+        vertexai.init(
+            project=settings.vertex_project,
+            location=settings.vertex_location,
+        )
+        self._model = GenerativeModel(settings.vertex_model)
+        self._initialised = True
+        logger.info(
+            "Vertex AI initialised (project=%s, location=%s, model=%s)",
+            settings.vertex_project,
+            settings.vertex_location,
+            settings.vertex_model,
+        )
+
+    async def generate(
+        self,
+        prompt: str,
+        temperature: float = 0.4,
+        max_tokens: int = 512,
+    ) -> str:
+        """
+        One-shot text generation. Returns the model's response as a string.
+
+        Args:
+            prompt: The full prompt to send.
+            temperature: Sampling temperature (lower = more deterministic).
+            max_tokens: Maximum tokens in the response.
+        """
+        self._ensure_init()
+        config = GenerationConfig(
+            temperature=temperature,
+            max_output_tokens=max_tokens,
+        )
+        try:
+            response = await self._model.generate_content_async(
+                prompt,
+                generation_config=config,
+            )
+            return response.text.strip()
+        except Exception:
+            logger.exception("generate() failed")
+            raise
+
+    async def run_agent(
+        self,
+        query: str,
+        tools: list[AgentTool],
+        temperature: float = 0.2,
+        max_turns: int = 6,
+    ) -> str:
+        """
+        Multi-turn agentic loop with function calling.
+
+        The model may call any of the provided tools zero or more times.
+        Tool handlers are called synchronously inside the loop.
+        Returns the final text response once the model stops issuing function calls.
+
+        Args:
+            query: Initial user query / task description.
+            tools: List of AgentTool instances the model can call.
+            temperature: Sampling temperature.
+            max_turns: Maximum number of model turns before giving up.
+        """
+        self._ensure_init()
+
+        declarations = [t.to_function_declaration() for t in tools]
+        tool_map = {t.name: t.handler for t in tools}
+        vertex_tools = [Tool(function_declarations=declarations)]
+
+        config = GenerationConfig(temperature=temperature)
+        model = GenerativeModel(
+            settings.vertex_model,
+            tools=vertex_tools,
+            generation_config=config,
+        )
+
+        chat = model.start_chat()
+        message = query
+
+        for turn in range(max_turns):
+            response = await chat.send_message_async(message)
+            candidate = response.candidates[0]
+
+            # Check if the model wants to call a function
+            function_calls = [
+                part.function_call
+                for part in candidate.content.parts
+                if part.function_call.name
+            ]
+
+            if not function_calls:
+                # No more tool calls — return the final text
+                return candidate.content.parts[0].text.strip()
+
+            # Execute each requested function and collect results
+            function_responses = []
+            for fc in function_calls:
+                handler = tool_map.get(fc.name)
+                if handler is None:
+                    result = {"error": f"Unknown tool: {fc.name}"}
+                else:
+                    try:
+                        result = handler(**dict(fc.args))
+                        if not isinstance(result, dict):
+                            result = {"result": result}
+                    except Exception as e:
+                        logger.warning("Tool %s raised: %s", fc.name, e)
+                        result = {"error": str(e)}
+
+                function_responses.append(
+                    Part.from_function_response(name=fc.name, response=result)
+                )
+
+            message = function_responses
+
+            if turn == max_turns - 1:
+                logger.warning("run_agent() hit max_turns=%d without a final text response", max_turns)
+                return ""
+
+        return ""
+
+
+# ---------------------------------------------------------------------------
+# Singleton
+# ---------------------------------------------------------------------------
+
+_instance: Optional[AIService] = None
+
+
+def get_ai_service() -> AIService:
+    """Return the shared AIService instance, creating it on first call."""
+    global _instance
+    if _instance is None:
+        _instance = AIService()
+    return _instance

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "httpx>=0.27.0",
     "schedule>=1.2.0",
+    "google-cloud-aiplatform>=1.60.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

- Adds `AIService` as the central LLM integration point, built on Gemini via Vertex AI
- `generate()` handles one-shot async text generation (news analysis, summaries)
- `run_agent()` handles multi-turn agentic loops with function calling tools
- `AgentTool` dataclass wraps callable handlers into Vertex AI `FunctionDeclaration` objects
- Shared `PROMPT_TEMPLATES` dict keeps prompts reusable across features
- Singleton `get_ai_service()` ensures one initialised instance per process
- Vertex AI settings (`VERTEX_PROJECT`, `VERTEX_LOCATION`, `VERTEX_MODEL`) added to config and documented in `.env.example`

## Test plan

- [x] Set `VERTEX_PROJECT`, `VERTEX_LOCATION`, `VERTEX_MODEL`, and `GOOGLE_APPLICATION_CREDENTIALS` in `.env`
- [x] Import and call `get_ai_service().generate("Hello")` — should return a string response
- [x] Confirm `run_agent()` executes tool handlers when the model issues function calls
- [x] Confirm startup logs show `Vertex AI initialised` with correct project/location/model
- [x] Confirm server starts cleanly without `VERTEX_PROJECT` set (lazy init — error only on first use)

Closes #83