### PR TITLE
Frontend: AI market analysis page

### DIFF
--- a/frontend/src/app/analysis/page.tsx
+++ b/frontend/src/app/analysis/page.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useState } from "react";
+import { useApi } from "@/hooks/useApi";
+import { getStockAnalysis, getCryptoAnalysis, triggerAnalysis } from "@/lib/api";
+import PageHeader from "@/components/layout/PageHeader";
+import MarketAnalysisCard from "@/components/analysis/MarketAnalysisCard";
+import { RefreshCw } from "@/components/icons";
+
+export default function AnalysisPage() {
+  const stocks = useApi(getStockAnalysis);
+  const crypto = useApi(getCryptoAnalysis);
+  const [triggering, setTriggering] = useState(false);
+  const [triggerMsg, setTriggerMsg] = useState<string | null>(null);
+
+  async function handleTrigger() {
+    setTriggering(true);
+    setTriggerMsg(null);
+    try {
+      const result = await triggerAnalysis();
+      setTriggerMsg(result.message);
+      stocks.refetch();
+      crypto.refetch();
+    } catch {
+      setTriggerMsg("Failed to trigger analysis. Check backend logs.");
+    } finally {
+      setTriggering(false);
+    }
+  }
+
+  return (
+    <div>
+      <PageHeader title="AI Market Analysis" />
+
+      <div className="flex items-center justify-between mb-6">
+        <p className="text-sm text-text-muted">
+          AI-generated summaries of current market conditions based on recent news.
+        </p>
+        <button
+          onClick={handleTrigger}
+          disabled={triggering}
+          className="flex items-center gap-2 text-sm px-3 py-1.5 rounded-lg border border-border-primary bg-surface-card hover:bg-surface-hover transition-colors disabled:opacity-50"
+        >
+          <RefreshCw className={`w-3.5 h-3.5 ${triggering ? "animate-spin" : ""}`} />
+          {triggering ? "Generating..." : "Refresh Analysis"}
+        </button>
+      </div>
+
+      {triggerMsg && (
+        <div className="mb-4 text-xs text-text-muted border border-border-subtle rounded-lg px-3 py-2 bg-surface-card">
+          {triggerMsg}
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <MarketAnalysisCard
+          title="Stock Market"
+          data={stocks.data}
+          loading={stocks.loading}
+          error={stocks.error}
+        />
+        <MarketAnalysisCard
+          title="Crypto Market"
+          data={crypto.data}
+          loading={crypto.loading}
+          error={crypto.error}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/analysis/MarketAnalysisCard.tsx
+++ b/frontend/src/components/analysis/MarketAnalysisCard.tsx
@@ -1,0 +1,42 @@
+import type { MarketAnalysisResponse } from "@/lib/types";
+import { formatDateShort } from "@/lib/format";
+
+interface Props {
+  title: string;
+  data: MarketAnalysisResponse | null;
+  loading: boolean;
+  error: string | null;
+}
+
+export default function MarketAnalysisCard({ title, data, loading, error }: Props) {
+  return (
+    <div className="border border-border-primary rounded-xl p-5 bg-surface-card">
+      <div className="flex justify-between items-center mb-3">
+        <h2 className="text-sm font-semibold">{title}</h2>
+        {data && (
+          <span className="text-xs text-text-muted">
+            {data.headline_count} headlines · {formatDateShort(data.generated_at)}
+          </span>
+        )}
+      </div>
+
+      {loading && (
+        <div className="space-y-2">
+          <div className="h-3 bg-surface-hover rounded animate-pulse w-full" />
+          <div className="h-3 bg-surface-hover rounded animate-pulse w-5/6" />
+          <div className="h-3 bg-surface-hover rounded animate-pulse w-4/6" />
+        </div>
+      )}
+
+      {error && !loading && (
+        <p className="text-sm text-text-muted italic">
+          No analysis available yet — trigger one to get started.
+        </p>
+      )}
+
+      {data && !loading && (
+        <p className="text-sm text-text-secondary leading-relaxed">{data.analysis}</p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/icons.tsx
+++ b/frontend/src/components/icons.tsx
@@ -129,6 +129,31 @@ export function ExternalLink(props: IconProps) {
   );
 }
 
+export function BrainCircuit(props: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      {...props}
+    >
+      <path d="M12 4.5a2.5 2.5 0 0 0-4.96-.46 2.5 2.5 0 0 0-1.98 3 2.5 2.5 0 0 0-1.32 4.24 3 3 0 0 0 .34 5.58 2.5 2.5 0 0 0 2.96 3.08A2.5 2.5 0 0 0 12 19.5" />
+      <path d="M12 4.5a2.5 2.5 0 0 1 4.96-.46 2.5 2.5 0 0 1 1.98 3 2.5 2.5 0 0 1 1.32 4.24 3 3 0 0 1-.34 5.58 2.5 2.5 0 0 1-2.96 3.08A2.5 2.5 0 0 1 12 19.5" />
+      <circle cx="12" cy="12" r="3" />
+      <line x1="12" x2="12" y1="9" y2="3" />
+      <line x1="6.5" x2="12" y1="13" y2="12" />
+      <line x1="17.5" x2="12" y1="13" y2="12" />
+      <line x1="12" x2="12" y1="15" y2="21" />
+    </svg>
+  );
+}
+
 export function Circle(props: IconProps) {
   return (
     <svg

--- a/frontend/src/components/layout/AppSidebar.tsx
+++ b/frontend/src/components/layout/AppSidebar.tsx
@@ -10,6 +10,7 @@ import {
   Newspaper,
   Settings,
   Circle,
+  BrainCircuit,
 } from "@/components/icons";
 
 const sections = [
@@ -24,6 +25,7 @@ const sections = [
     links: [
       { href: "/predictions", icon: TrendingUp, label: "Predictions" },
       { href: "/news", icon: Newspaper, label: "News" },
+      { href: "/analysis", icon: BrainCircuit, label: "AI Analysis" },
     ],
   },
   {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -9,6 +9,8 @@ import type {
   CryptoAlertHistory,
   CryptoWatchlistResponse,
   NewsFeedResponse,
+  MarketAnalysisResponse,
+  AnalysisTriggerResponse,
 } from "./types";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
@@ -48,3 +50,11 @@ export const getNewsFeed = () =>
   fetchApi<NewsFeedResponse>("/api/v1/news/feed");
 export const triggerNewsFetch = () =>
   fetchApi<ScanResultResponse>("/api/v1/news/fetch", { method: "POST" });
+
+// Market Analysis
+export const getStockAnalysis = () =>
+  fetchApi<MarketAnalysisResponse>("/api/v1/analysis/stocks");
+export const getCryptoAnalysis = () =>
+  fetchApi<MarketAnalysisResponse>("/api/v1/analysis/crypto");
+export const triggerAnalysis = () =>
+  fetchApi<AnalysisTriggerResponse>("/api/v1/analysis/trigger", { method: "POST" });

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -85,3 +85,15 @@ export interface NewsFeedResponse {
   crypto_count: number;
   articles: NewsArticle[];
 }
+
+export interface MarketAnalysisResponse {
+  category: string;
+  analysis: string;
+  headline_count: number;
+  generated_at: string;
+}
+
+export interface AnalysisTriggerResponse {
+  triggered: boolean;
+  message: string;
+}


### PR DESCRIPTION
## Summary

- Adds `/analysis` page with two-column layout showing AI-generated summaries for stock and crypto markets
- `MarketAnalysisCard` component handles loading skeleton, empty state (no analysis yet), and the analysis text with headline count and generation timestamp
- Refresh Analysis button calls `POST /api/v1/analysis/trigger`, shows a status message, and re-fetches both cards on completion
- `BrainCircuit` icon added to the shared icon set
- AI Analysis link added to the sidebar under the ANALYSIS section
- New API client functions: `getStockAnalysis`, `getCryptoAnalysis`, `triggerAnalysis`

## Test plan

- [x] Navigate to `/analysis` — both cards render (skeleton while loading, message if no analysis exists)
- [x] Click Refresh Analysis — button shows spinner, status message appears after completion
- [x] Both cards update with new analysis text and timestamps after refresh
- [x] AI Analysis appears in sidebar and highlights correctly when on the `/analysis` route
- [x] Page is responsive on mobile (cards stack vertically)

Closes #85