### PR TITLE
feat: centralised agent orchestrator + market analysis refactor

### DIFF
--- a/backend/app/api/v1/analysis.py
+++ b/backend/app/api/v1/analysis.py
@@ -59,10 +59,12 @@ async def get_crypto_analysis():
 async def trigger_analysis():
     """Trigger fresh AI market analysis for both stocks and crypto."""
     try:
-        await _get_analyzer().run_all()
+        stock_reasoning, crypto_reasoning = await _get_analyzer().run_all()
         return AnalysisTriggerResponse(
             triggered=True,
-            message="Market analysis updated for stocks and crypto.",
+            message="Market analysis agent completed.",
+            stocks_reasoning=stock_reasoning,
+            crypto_reasoning=crypto_reasoning,
         )
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/backend/app/engines/market_analysis/analyzer.py
+++ b/backend/app/engines/market_analysis/analyzer.py
@@ -2,7 +2,7 @@
 MarketAnalyzer — generates AI market summaries from recent news headlines.
 
 Reads from the news monitor's history file, groups headlines by category,
-and calls AIService.generate() using shared prompt templates.
+and uses the AgentOrchestrator to decide whether a fresh summary is needed.
 Results are cached in memory and persisted to a local JSON file so the
 last analysis survives a server restart.
 """
@@ -15,7 +15,8 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Optional
 
-from app.services.ai_service import PROMPT_TEMPLATES, get_ai_service
+from app.services.ai_service import AgentTool
+from app.services.agent_orchestrator import get_orchestrator
 
 logger = logging.getLogger(__name__)
 
@@ -40,12 +41,16 @@ class MarketAnalyzer:
     Categories map to the two sides of the news feed: 'stock' and 'crypto'.
     Analysis is triggered on a schedule via the scheduler, and also available
     on-demand through the POST /api/v1/analysis/trigger endpoint.
+
+    Uses the AgentOrchestrator so the agent decides whether to update the
+    cached summary rather than blindly regenerating it on every call.
     """
 
     def __init__(self, news_history_path: Optional[Path] = None):
         self._news_path = news_history_path or _NEWS_HISTORY_PATH
         self._cache: dict[str, MarketAnalysisResult] = {}
         self._load_cache()
+        self._register_tools()
 
     # ------------------------------------------------------------------
     # Cache persistence
@@ -108,45 +113,129 @@ class MarketAnalyzer:
             return []
 
     # ------------------------------------------------------------------
-    # Analysis generation
+    # Agent tool registration
     # ------------------------------------------------------------------
 
-    async def analyze(self, category: str) -> Optional[MarketAnalysisResult]:
-        """
-        Generate fresh AI analysis for 'stock' or 'crypto'.
+    def _register_tools(self):
+        get_orchestrator().register_tools([
+            AgentTool(
+                name="get_market_headlines",
+                description="Fetch recent news headlines for 'stock' or 'crypto' category.",
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "category": {"type": "string", "enum": ["stock", "crypto"]},
+                        "max_age_hours": {
+                            "type": "integer",
+                            "description": "Look-back window in hours (default 24).",
+                        },
+                    },
+                    "required": ["category"],
+                },
+                handler=self._tool_get_headlines,
+            ),
+            AgentTool(
+                name="get_market_analysis",
+                description="Read the current cached market analysis for 'stock' or 'crypto'.",
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "category": {"type": "string", "enum": ["stock", "crypto"]},
+                    },
+                    "required": ["category"],
+                },
+                handler=self._tool_get_current_analysis,
+            ),
+            AgentTool(
+                name="update_market_analysis",
+                description=(
+                    "Write a new market analysis to cache. Call only if the current analysis "
+                    "is outdated or missing. 5-7 sentences, no price predictions."
+                ),
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "category": {"type": "string", "enum": ["stock", "crypto"]},
+                        "analysis": {"type": "string"},
+                        "headline_count": {"type": "integer"},
+                    },
+                    "required": ["category", "analysis", "headline_count"],
+                },
+                handler=self._tool_update_analysis,
+            ),
+        ])
 
-        Returns the cached result if there are no headlines to analyse.
-        Returns None if there are no headlines and no cached result.
-        """
-        headlines = self._get_recent_headlines(category)
-        if not headlines:
-            logger.info("No recent %s headlines — returning cached result", category)
-            return self._cache.get(category)
+    # ------------------------------------------------------------------
+    # Tool handlers (synchronous — called by the agent loop)
+    # ------------------------------------------------------------------
 
-        template_key = f"market_analysis_{'stocks' if category == 'stock' else 'crypto'}"
-        prompt = PROMPT_TEMPLATES[template_key].format(
-            headlines="\n".join(f"- {h}" for h in headlines)
-        )
+    def _tool_get_headlines(self, category: str, max_age_hours: int = 24) -> dict:
+        headlines = self._get_recent_headlines(category, max_age_hours=max_age_hours)
+        return {
+            "category": category,
+            "headline_count": len(headlines),
+            "headlines": headlines,
+        }
 
-        ai = get_ai_service()
-        text = await ai.generate(prompt, temperature=0.5, max_tokens=1024)
+    def _tool_get_current_analysis(self, category: str) -> dict:
+        cached = self._cache.get(category)
+        if cached is None:
+            return {"category": category, "exists": False, "analysis": None}
+        return {
+            "category": category,
+            "exists": True,
+            "analysis": cached.analysis,
+            "headline_count": cached.headline_count,
+            "generated_at": cached.generated_at.isoformat(),
+        }
 
+    def _tool_update_analysis(
+        self, category: str, analysis: str, headline_count: int
+    ) -> dict:
         result = MarketAnalysisResult(
             category=category,
-            analysis=text,
-            headline_count=len(headlines),
+            analysis=analysis,
+            headline_count=headline_count,
         )
         self._cache[category] = result
         self._save_cache()
-
         logger.info(
-            "Generated %s analysis from %d headlines", category, len(headlines)
+            "Agent updated %s analysis (%d headlines)", category, headline_count
         )
-        return result
+        return {"success": True}
 
-    async def run_all(self):
-        """Analyse stocks and crypto in parallel."""
-        await asyncio.gather(self.analyze("stock"), self.analyze("crypto"))
+    # ------------------------------------------------------------------
+    # Analysis generation
+    # ------------------------------------------------------------------
+
+    async def analyze(self, category: str) -> str:
+        """
+        Run the agent to decide whether the cached analysis needs updating.
+
+        The agent reads the current headlines and cached summary, then either
+        updates the cache via update_market_analysis or leaves it unchanged.
+        Returns the agent's 1-2 sentence reasoning.
+        """
+        label = "stock market" if category == "stock" else "crypto market"
+        task = (
+            f"You are maintaining an up-to-date {label} analysis summary.\n\n"
+            f"Steps:\n"
+            f"1. Call get_market_headlines(category='{category}') to see available news.\n"
+            f"2. Call get_market_analysis(category='{category}') to read the existing summary.\n"
+            f"3. Decide: do the headlines include significant new developments not reflected "
+            f"in the current analysis? (new regulatory events, major moves, sentiment shifts)\n"
+            f"4. If yes — call update_market_analysis with a fresh 5-7 sentence summary "
+            f"covering key themes, sentiment, and risks. No price predictions.\n"
+            f"5. If no — do NOT call update_market_analysis.\n"
+            f"6. Reply with 1-2 sentences: what you decided and why."
+        )
+        tool_names = ["get_market_headlines", "get_market_analysis", "update_market_analysis"]
+        reasoning = await get_orchestrator().run_task(task, tool_names=tool_names)
+        return reasoning or f"Agent completed {category} analysis."
+
+    async def run_all(self) -> tuple[str, str]:
+        """Analyse stocks and crypto in parallel. Returns agent reasoning for each."""
+        return await asyncio.gather(self.analyze("stock"), self.analyze("crypto"))
 
     def get_cached(self, category: str) -> Optional[MarketAnalysisResult]:
         """Return the latest cached result without triggering generation."""

--- a/backend/app/models/analysis.py
+++ b/backend/app/models/analysis.py
@@ -15,3 +15,5 @@ class MarketAnalysisResponse(BaseModel):
 class AnalysisTriggerResponse(BaseModel):
     triggered: bool
     message: str
+    stocks_reasoning: str = ""
+    crypto_reasoning: str = ""

--- a/backend/app/services/agent_orchestrator.py
+++ b/backend/app/services/agent_orchestrator.py
@@ -1,0 +1,106 @@
+"""
+Central AI agent orchestrator.
+
+All features that need agentic behaviour register their tools here
+and call run_task() rather than invoking AIService.run_agent() directly.
+
+This gives a single place to:
+- Track AI API usage (prevent runaway costs)
+- Enforce staleness guards (skip if result is still fresh)
+- Log all agentic activity across the system
+"""
+
+import logging
+from datetime import datetime, timedelta
+from typing import Optional
+
+from app.services.ai_service import AgentTool, get_ai_service
+
+logger = logging.getLogger(__name__)
+
+# Hard limit: max agent calls per hour across the whole system.
+# Prevents runaway costs if a bug triggers rapid retries.
+_MAX_CALLS_PER_HOUR = 20
+
+
+class AgentOrchestrator:
+    def __init__(self):
+        self._tools: dict[str, AgentTool] = {}
+        self._call_log: list[datetime] = []  # rolling window for rate limiting
+
+    def register_tool(self, tool: AgentTool) -> None:
+        """Register a tool so the agent can call it."""
+        self._tools[tool.name] = tool
+        logger.debug("Registered agent tool: %s", tool.name)
+
+    def register_tools(self, tools: list[AgentTool]) -> None:
+        for tool in tools:
+            self.register_tool(tool)
+
+    def _check_rate_limit(self) -> bool:
+        """Return True if within limit, False if over budget."""
+        now = datetime.now()
+        cutoff = now - timedelta(hours=1)
+        self._call_log = [t for t in self._call_log if t > cutoff]
+        if len(self._call_log) >= _MAX_CALLS_PER_HOUR:
+            logger.warning(
+                "Agent rate limit reached (%d calls in last hour)", len(self._call_log)
+            )
+            return False
+        return True
+
+    async def run_task(
+        self,
+        task: str,
+        tool_names: Optional[list[str]] = None,
+        temperature: float = 0.2,
+        max_turns: int = 8,
+    ) -> str:
+        """
+        Run an agentic task.
+
+        Args:
+            task:        Natural language description of what the agent should do.
+            tool_names:  Subset of registered tools to expose to the agent.
+                         If None, all registered tools are available.
+            temperature: Sampling temperature (default 0.2 for consistent reasoning).
+            max_turns:   Max agent turns before giving up.
+
+        Returns:
+            The agent's final text response.
+        """
+        if not self._check_rate_limit():
+            return "Skipped: agent rate limit reached. Try again later."
+
+        if tool_names is not None:
+            tools = [self._tools[n] for n in tool_names if n in self._tools]
+        else:
+            tools = list(self._tools.values())
+
+        if not tools:
+            logger.warning("run_task called with no available tools")
+            return "No tools available for this task."
+
+        self._call_log.append(datetime.now())
+        logger.info("Agent task started (tools: %s)", [t.name for t in tools])
+
+        result = await get_ai_service().run_agent(
+            task, tools, temperature=temperature, max_turns=max_turns
+        )
+        logger.info("Agent task complete")
+        return result
+
+
+# ---------------------------------------------------------------------------
+# Singleton
+# ---------------------------------------------------------------------------
+
+_orchestrator: Optional[AgentOrchestrator] = None
+
+
+def get_orchestrator() -> AgentOrchestrator:
+    """Return the shared AgentOrchestrator instance, creating it on first call."""
+    global _orchestrator
+    if _orchestrator is None:
+        _orchestrator = AgentOrchestrator()
+    return _orchestrator

--- a/backend/app/services/ai_service.py
+++ b/backend/app/services/ai_service.py
@@ -147,6 +147,7 @@ class AIService:
         config = types.GenerateContentConfig(
             tools=[vertex_tool],
             temperature=temperature,
+            thinking_config=types.ThinkingConfig(thinking_budget=0),
         )
 
         chat = self._client.aio.chats.create(


### PR DESCRIPTION
Closes #89

## Summary

- Adds `AgentOrchestrator` singleton (`backend/app/services/agent_orchestrator.py`) — a centralised entry point for all agentic tasks, with a tool registry and a 20-calls/hour rate limiter.
- Refactors `MarketAnalyzer` to register three agent tools and use `run_task()` instead of calling `generate()` directly. The agent now inspects existing headlines vs the cached summary and only updates when there are significant new developments.
- `POST /api/v1/analysis/trigger` response now includes `stocks_reasoning` and `crypto_reasoning` — the agent's decision summary for each category.
- Fixes missing `thinking_config` in `run_agent()` (same truncation fix already applied to `generate()`).

## Files changed

| File | Change |
|---|---|
| `backend/app/services/agent_orchestrator.py` | New — orchestrator singleton |
| `backend/app/services/ai_service.py` | Add `thinking_config` to `run_agent()` |
| `backend/app/models/analysis.py` | Add `stocks_reasoning` + `crypto_reasoning` to trigger response |
| `backend/app/engines/market_analysis/analyzer.py` | Refactor to use orchestrator; `analyze()` returns agent reasoning |
| `backend/app/api/v1/analysis.py` | Unpack + return reasoning from `run_all()` |

## Test plan

- [x] `POST /api/v1/analysis/trigger` — response includes `stocks_reasoning` and `crypto_reasoning` strings
- [x] `GET /api/v1/analysis/stocks` and `/crypto` — return cached analysis if the agent updated it
- [x] Press "Refresh Analysis" — frontend info box shows agent reasoning
- [x] Backend logs show `"Agent task started"` and optionally `"Agent updated stock analysis"`
- [x] Trigger rapidly — rate limiter returns `"Skipped: agent rate limit reached"` after 20 calls/hour